### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,24 +6,24 @@
 # Instances 				(KEYWORD1)
 #######################################
 
-xCore KEYWORD1		
+xCore	KEYWORD1
 
 #######################################
 # Methods and Functions 	(KEYWORD2)
 #######################################
 
-request16 KEYWORD2
-write KEYWORD2   
-write1  KEYWORD2
-write8  KEYWORD2
-write16 KEYWORD2
-read8 KEYWORD2
-readStream  KEYWORD2
-readS16 KEYWORD2
-read16_LE KEYWORD2
-readS16_LE  KEYWORD2
-read24  KEYWORD2
-ping  KEYWORD2
+request16	KEYWORD2
+write	KEYWORD2
+write1	KEYWORD2
+write8	KEYWORD2
+write16	KEYWORD2
+read8	KEYWORD2
+readStream	KEYWORD2
+readS16	KEYWORD2
+read16_LE	KEYWORD2
+readS16_LE	KEYWORD2
+read24	KEYWORD2
+ping	KEYWORD2
 
 #######################################
 # Constants 				(LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords